### PR TITLE
Perf

### DIFF
--- a/src/Bench.jl
+++ b/src/Bench.jl
@@ -99,11 +99,27 @@ function SolveModel(initgrid)
     end
 end
 
+# TODO not use my own bespoke describe function
+function impl_describe(df::DataFrame)
+    function q10(col)
+        quantile(col, 0.1)
+    end
+    function q90(col)
+        quantile(col, 0.9)
+    end
+    fns = [mean, minimum, q10, median, q90, maximum]
+    res = DataFrame(impl=[:Julia, :JuMP, :Python])
+    for f=fns
+        res[symbol(string(f))] = [f(col) for (cname,col)=eachcol(df)]
+    end
+    res
+end
+
 
 N = (length(ARGS) == 1) ? int(ARGS[1]) : 100
 b = bench_compare(N)
-println(b)
-m = round(median(b[:Julia]) / median(b[:Python]) * 100 - 100, 1)
-println("Julia $m% slower than Python")
+s = impl_describe(b)
+println(s)
 
 # TODO more desciptive stats from result
+# TODO eg plot of sorted times?

--- a/src/Sudoku.jl
+++ b/src/Sudoku.jl
@@ -202,10 +202,10 @@ function solve_all(grids; name="", showif=0.2)
     #times, results = zip([time_solve(grid, showif) for grid=grids]...)
     N = length(grids)
     if N > 1
-        t_mean = round(sum(times)/N, 2)
-        t_hz = round(N/sum(times), 2)
-        t_max = round(maximum(times), 2)
-        println("Solved $(sum(results)) of $N $name puzzles (avg $t_mean secs ($t_hz Hz), max $t_max secs).")
+        t_mean = round(sum(times)/N, 3)
+        t_hz = round(N/sum(times), 3)
+        t_max = round(maximum(times), 3)
+        println("Solved $(sum(results)) of $N $name puzzles (avg $(t_mean)s ($(t_hz)Hz), max $(t_max)s).")
     end
 end
 


### PR DESCRIPTION
As suggested on the [mailing list](https://groups.google.com/forum/#!topic/julia-users/bzhhJCGLxCM), make the globals const. (this seemed to speed up median solve by 30% and making it faster than python).

I tried to replace "total overkill" dict in solve, but couldn't get it working,,,

TODO update readme to reflect this (Have a feeling there will be some more perf to come, e.g. type stability.)
